### PR TITLE
Remove refs from BOM links

### DIFF
--- a/docs/initial-setup.md
+++ b/docs/initial-setup.md
@@ -151,15 +151,15 @@ It is recommended to run it inside `tmux` so it continues running even if you di
 
 | Item                                  | Link                                                                                                     | Optional |
 |---------------------------------------|----------------------------------------------------------------------------------------------------------|----------|
-| Wio WM6180 Wi-Fi HaLow mini PCIe Module | https://www.seeedstudio.com/Wio-WM6180-Wi-Fi-HaLow-mini-PCIe-Module-p-6394.html                         | No       |
-| WM1302 Pi Hat                         | https://www.seeedstudio.com/WM1302-Pi-Hat-p-4897.html                                                   | No       |
-| External Antenna 868/915 MHz 2 dBi SMA L195 mm Foldable | https://www.seeedstudio.com/External-Antenna-868-915MHZ-2dBi-SMA-L195mm-Foldable-p-5863.html            | No       |
-| UF.L to SMA-K 1.13 mm 120 mm Cable    | https://www.seeedstudio.com/UF-L-SMA-K-1-13-120mm-p-5046.html                                           | No       |
-| Raspberry Pi 4 Computer Model B – 1 GB | https://www.seeedstudio.com/Raspberry-Pi-4-Computer-Model-B-1GB-p-4078.html                             | No       |
-| 21700 Batteries                       | https://www.amazon.com/dp/B0D3GX96H6?ref_=ppx_hzsearch_conn_dt_b_fed_asin_title_4                       | Yes      |
-| WaveShare UPS B                       | https://www.amazon.com/gp/product/B0D39VDMDP/ref=ox_sc_saved_title_1?smid=A3B0XDFTVR980O&psc=1          | Yes      |
-| Panda USB Wi-Fi Adapter (PAU06)       | https://www.amazon.com/dp/B00762YNMG?ref_=ppx_hzsearch_conn_dt_b_fed_asin_title_1                       | Yes      |
-| GPS USB Adapter                       | https://www.amazon.com/dp/B01MTU9KTF?ref_=ppx_hzsearch_conn_dt_b_fed_asin_title_1                       | Yes      |
+| Wio WM6180 Wi-Fi HaLow mini PCIe Module | <https://www.seeedstudio.com/Wio-WM6180-Wi-Fi-HaLow-mini-PCIe-Module-p-6394.html>                         | No       |
+| WM1302 Pi Hat                         | <https://www.seeedstudio.com/WM1302-Pi-Hat-p-4897.html>                                                   | No       |
+| External Antenna 868/915 MHz 2 dBi SMA L195 mm Foldable | <https://www.seeedstudio.com/External-Antenna-868-915MHZ-2dBi-SMA-L195mm-Foldable-p-5863.html>            | No       |
+| UF.L to SMA-K 1.13 mm 120 mm Cable    | <https://www.seeedstudio.com/UF-L-SMA-K-1-13-120mm-p-5046.html>                                           | No       |
+| Raspberry Pi 4 Computer Model B – 1 GB | <https://www.seeedstudio.com/Raspberry-Pi-4-Computer-Model-B-1GB-p-4078.html>                             | No       |
+| 21700 Batteries                       | <https://www.amazon.com/dp/B0D3GX96H6>                                                                     | Yes      |
+| WaveShare UPS B                       | <https://www.amazon.com/gp/product/B0D39VDMDP>                                                            | Yes      |
+| Panda USB Wi-Fi Adapter (PAU06)       | <https://www.amazon.com/dp/B00762YNMG>                                                                     | Yes      |
+| GPS USB Adapter                       | <https://www.amazon.com/dp/B01MTU9KTF>                                                                     | Yes      |
 
 ---
 


### PR DESCRIPTION
This commit removes the refs from the amazon BOM links and makes them actual links in the markdown.